### PR TITLE
Wrap command sender using weak references

### DIFF
--- a/platform-paper/src/main/java/de/pianoman911/playerculling/platformpaper/platform/PaperCommandSender.java
+++ b/platform-paper/src/main/java/de/pianoman911/playerculling/platformpaper/platform/PaperCommandSender.java
@@ -5,19 +5,27 @@ import de.pianoman911.playerculling.platformcommon.platform.command.PlatformComm
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.util.TriState;
 import org.bukkit.command.CommandSender;
+import org.jspecify.annotations.NullMarked;
 
+import java.lang.ref.WeakReference;
+
+@NullMarked
 public class PaperCommandSender<T extends CommandSender> implements PlatformCommandSender {
 
     protected final PaperPlatform platform;
-    protected final T sender;
+    protected final WeakReference<T> sender;
 
     public PaperCommandSender(PaperPlatform platform, T sender) {
         this.platform = platform;
-        this.sender = sender;
+        this.sender = new WeakReference<>(sender);
     }
 
     public final T getDelegate() {
-        return this.sender;
+        T delegate = this.sender.get();
+        if (delegate != null) {
+            return delegate;
+        }
+        throw new IllegalStateException("Delegate of " + this + " has been garbage collected");
     }
 
     @Override
@@ -27,16 +35,15 @@ public class PaperCommandSender<T extends CommandSender> implements PlatformComm
 
     @Override
     public void sendMessage(Component message) {
-        this.sender.sendMessage(message);
+        this.getDelegate().sendMessage(message);
     }
 
     @Override
     public boolean hasPermission(String permission, TriState defaultValue) {
-        if (!defaultValue.equals(TriState.NOT_SET)) {
-            if (this.sender.isPermissionSet(permission)){
-                return Boolean.TRUE.equals(defaultValue.toBoolean());
-            }
+        T delegate = this.getDelegate();
+        if (defaultValue != TriState.NOT_SET && !delegate.isPermissionSet(permission)) {
+            return defaultValue == TriState.TRUE;
         }
-        return this.sender.hasPermission(permission);
+        return delegate.hasPermission(permission);
     }
 }

--- a/platform-paper/src/main/java/de/pianoman911/playerculling/platformpaper/platform/PaperPlayer.java
+++ b/platform-paper/src/main/java/de/pianoman911/playerculling/platformpaper/platform/PaperPlayer.java
@@ -28,7 +28,7 @@ public class PaperPlayer extends PaperLivingEntity<Player> implements PlatformPl
     @Override
     public boolean isSpectator() {
         // use nms for checking spectator mode, faster than using bukkit gamemode comparison
-        return this.platform.getNmsAdapter().isSpectator(this.sender);
+        return this.platform.getNmsAdapter().isSpectator(this.getDelegate());
     }
 
     @Override
@@ -84,7 +84,7 @@ public class PaperPlayer extends PaperLivingEntity<Player> implements PlatformPl
     @Override
     public boolean canSeeNameTag(PlatformPlayer targetPlayer) {
         Player target = ((PaperPlayer) targetPlayer).getDelegate();
-        return this.platform.getNmsAdapter().canSeeNametag(this.sender, target);
+        return this.platform.getNmsAdapter().canSeeNametag(this.getDelegate(), target);
     }
 
     @Override


### PR DESCRIPTION
Prevents memory leaks caused by our wrapper objects not being de-allocated