### PR TITLE
fix: prevent false player culling on roof transitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,8 @@ following options:
 - `culling`:
     - `nametag-visibility-distance`: The distance in blocks PlayerCulling will check for nametag visibility. Set to `0` to
       ignore nametags completely (default: `64`, vanilla)
+    - `always-visible-distance`: The distance in blocks where players are always visible without occlusion checks. Set to
+      `0` to disable this bypass (default: `1.75`)
     - `blacklisted_worlds`: A list of worlds where PlayerCulling should be disabled (default: `[]`)
 - `updater`:
     - `enabled`: Enables/disables the update checker (default: `true`)

--- a/core/src/main/java/de/pianoman911/playerculling/core/culling/CullPlayer.java
+++ b/core/src/main/java/de/pianoman911/playerculling/core/culling/CullPlayer.java
@@ -30,6 +30,8 @@ public final class CullPlayer {
     private static final long DARKNESS_MIN_MS = 2000;
     private static final long BLINDNESS_FADE_OUT_TICKS = 25;
     private static final long DARKNESS_FADE_OUT_TICKS = 30;
+    private static final long TELEPORT_GRACE_TICKS = 40;
+    private static final double TELEPORT_DISTANCE_SQUARED = 16 * 16;
 
     private final CullShip ship;
     private final PlatformPlayer player;
@@ -47,6 +49,11 @@ public final class CullPlayer {
 
     private boolean cullingEnabled = true;
     private boolean spectating = false;
+    private long forceVisibleUntilTick = -1;
+    private boolean hasLastEyePosition = false;
+    private double lastEyeX;
+    private double lastEyeY;
+    private double lastEyeZ;
     private long lastDarkness = -1;
     private long lastRaySteps = 0L;
 
@@ -139,13 +146,24 @@ public final class CullPlayer {
             this.hidden.clear();
             return;
         }
-
         List<PlatformPlayer> playersInWorld = world.getPlayers();
         if (playersInWorld.size() <= 1) {
             return; // No need to cull if no other players are in the world
         }
         this.provider.world(world);
         Vec3d eye = this.player.getEyePosition();
+        if (this.hasLastEyePosition
+                && eye.distanceSquared(this.lastEyeX, this.lastEyeY, this.lastEyeZ) > TELEPORT_DISTANCE_SQUARED) {
+            this.forceVisibleForTicks(TELEPORT_GRACE_TICKS);
+        }
+        this.lastEyeX = eye.getX();
+        this.lastEyeY = eye.getY();
+        this.lastEyeZ = eye.getZ();
+        this.hasLastEyePosition = true;
+        if (this.ship.getPlatform().getCurrentTick() <= this.forceVisibleUntilTick) {
+            this.hidden.clear();
+            return;
+        }
 
         boolean blindness;
         boolean darkness;
@@ -176,6 +194,7 @@ public final class CullPlayer {
         double trackingDistSq = trackingDist * trackingDist;
 
         double nametagVisibilityDistSq = this.ship.getConfig().getDelegate().culling.getNametagVisibilityDistanceSquared();
+        double alwaysVisibleDistSq = this.ship.getConfig().getDelegate().culling.getAlwaysVisibleDistanceSquared();
 
         for (PlatformPlayer worldPlayer : playersInWorld) {
             if (worldPlayer == this.player) {
@@ -183,6 +202,10 @@ public final class CullPlayer {
             }
 
             double distSq = eye.distanceSquared(worldPlayer.getPosition());
+            if (distSq <= alwaysVisibleDistSq) {
+                this.unhide(worldPlayer, distSq <= trackingDistSq);
+                continue;
+            }
             boolean nameTag = distSq <= nametagVisibilityDistSq && this.player.canSeeNameTag(worldPlayer);
 
             if (
@@ -361,5 +384,16 @@ public final class CullPlayer {
 
     public void setSpectating(boolean spectating) {
         this.spectating = spectating;
+    }
+
+    public void forceVisibleForTicks(long ticks) {
+        if (ticks <= 0) {
+            return;
+        }
+        long until = this.ship.getPlatform().getCurrentTick() + ticks;
+        if (until > this.forceVisibleUntilTick) {
+            this.forceVisibleUntilTick = until;
+        }
+        this.resetHidden();
     }
 }

--- a/core/src/main/java/de/pianoman911/playerculling/core/occlusion/FacedOcclusionStepping.java
+++ b/core/src/main/java/de/pianoman911/playerculling/core/occlusion/FacedOcclusionStepping.java
@@ -30,7 +30,7 @@ public final class FacedOcclusionStepping {
      * @return positive ray steps if occluded, negative ray steps if not occluded
      */
     public static int scanOccluded(
-            DataProvider provider, Vec3d start, Vec3i startVoxel,
+            DataProvider provider, Vec3d start, Vec3i startVoxel, Vec3i targetVoxel,
             double maxDistanceSqrt, double dirX, double dirY, double dirZ
     ) {
         final int maxDistanceInt;
@@ -171,6 +171,15 @@ public final class FacedOcclusionStepping {
         int y0 = startVoxel.getY();
         int z0 = startVoxel.getZ();
 
+        // Constrain hit checks to the voxel bounds spanned by start and target.
+        // This avoids false positives from numerical stepping drift (e.g. bedrock roof below the ray).
+        final int minX = Math.min(x0, targetVoxel.getX());
+        final int minY = Math.min(y0, targetVoxel.getY());
+        final int minZ = Math.min(z0, targetVoxel.getZ());
+        final int maxX = Math.max(x0, targetVoxel.getX());
+        final int maxY = Math.max(y0, targetVoxel.getY());
+        final int maxZ = Math.max(z0, targetVoxel.getZ());
+
         // Check vector
         int xC;
         int yC;
@@ -214,6 +223,15 @@ public final class FacedOcclusionStepping {
                 x0 = xC;
                 y0 = yC;
                 z0 = zC;
+            }
+            // The ray reached the target voxel: don't continue behind the target and hit unrelated geometry.
+            if (x0 == targetVoxel.getX() && y0 == targetVoxel.getY() && z0 == targetVoxel.getZ()) {
+                return -currentDistance;
+            }
+            if (x0 < minX || x0 > maxX
+                    || y0 < minY || y0 > maxY
+                    || z0 < minZ || z0 > maxZ) {
+                continue; // out-of-bounds for this ray segment, skip occlusion test
             }
             if (provider.isOpaqueFullCube(x0, y0, z0)) { // If the voxel is opaque break
                 return currentDistance;

--- a/core/src/main/java/de/pianoman911/playerculling/core/occlusion/OcclusionCullingInstance.java
+++ b/core/src/main/java/de/pianoman911/playerculling/core/occlusion/OcclusionCullingInstance.java
@@ -40,6 +40,7 @@ public final class OcclusionCullingInstance {
 
     // Reused allocated data structures
     private final Vec3i startVoxel = new Vec3i(0, 0, 0);
+    private final Vec3i targetVoxel = new Vec3i(0, 0, 0);
     private long raySteps;
 
     public OcclusionCullingInstance(DataProvider provider) {
@@ -268,15 +269,16 @@ public final class OcclusionCullingInstance {
     }
 
     private boolean scanVisible(Vec3d posStart, Vec3i startVoxel, double x, double y, double z) {
+        this.targetVoxel.set((int) Math.floor(x), (int) Math.floor(y), (int) Math.floor(z));
         double dirX = x - posStart.x;
         double dirY = y - posStart.y;
         double dirZ = z - posStart.z;
         double dirLen = Math.sqrt(dirX * dirX + dirY * dirY + dirZ * dirZ);
         int steps = FacedOcclusionStepping.scanOccluded(
-                this.provider, posStart, startVoxel, posStart.distanceSquared(x, y, z),
+                this.provider, posStart, startVoxel, this.targetVoxel, posStart.distanceSquared(x, y, z),
                 dirX / dirLen, dirY / dirLen, dirZ / dirLen);
-        if (steps < 0) {
-            this.raySteps -= steps;
+        if (steps <= 0) {
+            this.raySteps += Math.max(0, -steps);
             return true;
         }
         this.raySteps += steps;

--- a/core/src/main/java/de/pianoman911/playerculling/core/provider/ChunkOcclusionDataProvider.java
+++ b/core/src/main/java/de/pianoman911/playerculling/core/provider/ChunkOcclusionDataProvider.java
@@ -28,6 +28,7 @@ public final class ChunkOcclusionDataProvider implements DataProvider {
         if (!world.equals(this.world)) {
             this.world = world;
             this.cache = world.getOcclusionWorldCache();
+            this.chunk = null; // invalidate per-world chunk cache on dimension/world switch
         }
     }
 

--- a/platform-common/src/main/java/de/pianoman911/playerculling/platformcommon/config/PlayerCullingConfig.java
+++ b/platform-common/src/main/java/de/pianoman911/playerculling/platformcommon/config/PlayerCullingConfig.java
@@ -52,10 +52,15 @@ public final class PlayerCullingConfig {
     public final static class Culling {
 
         public double nametagVisibilityDistance = 64; // blocks
+        public double alwaysVisibleDistance = 1.75; // blocks
         public Set<Key> blacklistedWorlds = Set.of();
 
         public double getNametagVisibilityDistanceSquared() {
             return this.nametagVisibilityDistance * this.nametagVisibilityDistance;
+        }
+
+        public double getAlwaysVisibleDistanceSquared() {
+            return this.alwaysVisibleDistance * this.alwaysVisibleDistance;
         }
     }
 

--- a/platform-fabric-12111/src/main/java/de/pianoman911/playerculling/platformfabric12111/PlayerCullingListener.java
+++ b/platform-fabric-12111/src/main/java/de/pianoman911/playerculling/platformfabric12111/PlayerCullingListener.java
@@ -9,6 +9,7 @@ import de.pianoman911.playerculling.platformfabric12111.common.IServerLevel;
 import de.pianoman911.playerculling.platformfabric12111.platform.FabricCommandSourceStack;
 import de.pianoman911.playerculling.platformfabric12111.platform.FabricWorld;
 import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
+import net.fabricmc.fabric.api.entity.event.v1.ServerEntityWorldChangeEvents;
 import net.fabricmc.fabric.api.entity.event.v1.ServerPlayerEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
@@ -26,10 +27,12 @@ public class PlayerCullingListener implements
         ServerPlayConnectionEvents.Join,
         ServerPlayConnectionEvents.Disconnect,
         ServerPlayerEvents.AfterRespawn,
+        ServerEntityWorldChangeEvents.AfterPlayerChange,
         ServerTickEvents.EndWorldTick,
         ServerLifecycleEvents.ServerStopped,
         CommandRegistrationCallback {
 
+    private static final long WORLD_CHANGE_GRACE_TICKS = 40L;
     private final PlayerCullingMod plugin;
 
     public PlayerCullingListener(PlayerCullingMod plugin) {
@@ -39,6 +42,7 @@ public class PlayerCullingListener implements
     public void register() {
         ServerPlayConnectionEvents.JOIN.register(this);
         ServerPlayConnectionEvents.DISCONNECT.register(this);
+        ServerEntityWorldChangeEvents.AFTER_PLAYER_CHANGE_WORLD.register(this);
         ServerTickEvents.END_WORLD_TICK.register(this);
         ServerLifecycleEvents.SERVER_STOPPED.register(this);
         CommandRegistrationCallback.EVENT.register(this);
@@ -62,6 +66,23 @@ public class PlayerCullingListener implements
             return; // cull player is null, ignore
         }
         player.setSpectating(false);
+    }
+
+    @Override
+    public void afterChangeWorld(ServerPlayer player, ServerLevel origin, ServerLevel destination) {
+        CullPlayer cullPlayer = this.plugin.getCullShip().getPlayer(player.getUUID());
+        if (cullPlayer != null) {
+            cullPlayer.resetHidden();
+            cullPlayer.setSpectating(false);
+            cullPlayer.forceVisibleForTicks(WORLD_CHANGE_GRACE_TICKS);
+        }
+        var destinationKey = ((IServerLevel) destination).getCullWorldOrCreate().getKey();
+        for (CullPlayer other : this.plugin.getCullShip().getPlayers()) {
+            other.invalidateOther(player.getUUID());
+            if (other.getPlatformPlayer().getWorld().getKey().equals(destinationKey)) {
+                other.forceVisibleForTicks(WORLD_CHANGE_GRACE_TICKS);
+            }
+        }
     }
 
     @Override

--- a/platform-fabric-1214/src/main/java/de/pianoman911/playerculling/platformfabric1214/PlayerCullingListener.java
+++ b/platform-fabric-1214/src/main/java/de/pianoman911/playerculling/platformfabric1214/PlayerCullingListener.java
@@ -9,6 +9,7 @@ import de.pianoman911.playerculling.platformfabric1214.common.IServerLevel;
 import de.pianoman911.playerculling.platformfabric1214.platform.FabricCommandSourceStack;
 import de.pianoman911.playerculling.platformfabric1214.platform.FabricWorld;
 import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
+import net.fabricmc.fabric.api.entity.event.v1.ServerEntityWorldChangeEvents;
 import net.fabricmc.fabric.api.entity.event.v1.ServerPlayerEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
@@ -26,10 +27,12 @@ public class PlayerCullingListener implements
         ServerPlayConnectionEvents.Join,
         ServerPlayConnectionEvents.Disconnect,
         ServerPlayerEvents.AfterRespawn,
+        ServerEntityWorldChangeEvents.AfterPlayerChange,
         ServerTickEvents.EndWorldTick,
         ServerLifecycleEvents.ServerStopped,
         CommandRegistrationCallback {
 
+    private static final long WORLD_CHANGE_GRACE_TICKS = 40L;
     private final PlayerCullingMod plugin;
 
     public PlayerCullingListener(PlayerCullingMod plugin) {
@@ -39,6 +42,7 @@ public class PlayerCullingListener implements
     public void register() {
         ServerPlayConnectionEvents.JOIN.register(this);
         ServerPlayConnectionEvents.DISCONNECT.register(this);
+        ServerEntityWorldChangeEvents.AFTER_PLAYER_CHANGE_WORLD.register(this);
         ServerTickEvents.END_WORLD_TICK.register(this);
         ServerLifecycleEvents.SERVER_STOPPED.register(this);
         CommandRegistrationCallback.EVENT.register(this);
@@ -62,6 +66,23 @@ public class PlayerCullingListener implements
             return; // cull player is null, ignore
         }
         player.setSpectating(false);
+    }
+
+    @Override
+    public void afterChangeWorld(ServerPlayer player, ServerLevel origin, ServerLevel destination) {
+        CullPlayer cullPlayer = this.plugin.getCullShip().getPlayer(player.getUUID());
+        if (cullPlayer != null) {
+            cullPlayer.resetHidden();
+            cullPlayer.setSpectating(false);
+            cullPlayer.forceVisibleForTicks(WORLD_CHANGE_GRACE_TICKS);
+        }
+        var destinationKey = ((IServerLevel) destination).getCullWorldOrCreate().getKey();
+        for (CullPlayer other : this.plugin.getCullShip().getPlayers()) {
+            other.invalidateOther(player.getUUID());
+            if (other.getPlatformPlayer().getWorld().getKey().equals(destinationKey)) {
+                other.forceVisibleForTicks(WORLD_CHANGE_GRACE_TICKS);
+            }
+        }
     }
 
     @Override

--- a/platform-fabric-1217/src/main/java/de/pianoman911/playerculling/platformfabric1217/PlayerCullingListener.java
+++ b/platform-fabric-1217/src/main/java/de/pianoman911/playerculling/platformfabric1217/PlayerCullingListener.java
@@ -9,6 +9,7 @@ import de.pianoman911.playerculling.platformfabric1217.common.IServerLevel;
 import de.pianoman911.playerculling.platformfabric1217.platform.FabricCommandSourceStack;
 import de.pianoman911.playerculling.platformfabric1217.platform.FabricWorld;
 import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
+import net.fabricmc.fabric.api.entity.event.v1.ServerEntityWorldChangeEvents;
 import net.fabricmc.fabric.api.entity.event.v1.ServerPlayerEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
@@ -26,10 +27,12 @@ public class PlayerCullingListener implements
         ServerPlayConnectionEvents.Join,
         ServerPlayConnectionEvents.Disconnect,
         ServerPlayerEvents.AfterRespawn,
+        ServerEntityWorldChangeEvents.AfterPlayerChange,
         ServerTickEvents.EndWorldTick,
         ServerLifecycleEvents.ServerStopped,
         CommandRegistrationCallback {
 
+    private static final long WORLD_CHANGE_GRACE_TICKS = 40L;
     private final PlayerCullingMod plugin;
 
     public PlayerCullingListener(PlayerCullingMod plugin) {
@@ -39,6 +42,7 @@ public class PlayerCullingListener implements
     public void register() {
         ServerPlayConnectionEvents.JOIN.register(this);
         ServerPlayConnectionEvents.DISCONNECT.register(this);
+        ServerEntityWorldChangeEvents.AFTER_PLAYER_CHANGE_WORLD.register(this);
         ServerTickEvents.END_WORLD_TICK.register(this);
         ServerLifecycleEvents.SERVER_STOPPED.register(this);
         CommandRegistrationCallback.EVENT.register(this);
@@ -62,6 +66,23 @@ public class PlayerCullingListener implements
             return; // cull player is null, ignore
         }
         player.setSpectating(false);
+    }
+
+    @Override
+    public void afterChangeWorld(ServerPlayer player, ServerLevel origin, ServerLevel destination) {
+        CullPlayer cullPlayer = this.plugin.getCullShip().getPlayer(player.getUUID());
+        if (cullPlayer != null) {
+            cullPlayer.resetHidden();
+            cullPlayer.setSpectating(false);
+            cullPlayer.forceVisibleForTicks(WORLD_CHANGE_GRACE_TICKS);
+        }
+        var destinationKey = ((IServerLevel) destination).getCullWorldOrCreate().getKey();
+        for (CullPlayer other : this.plugin.getCullShip().getPlayers()) {
+            other.invalidateOther(player.getUUID());
+            if (other.getPlatformPlayer().getWorld().getKey().equals(destinationKey)) {
+                other.forceVisibleForTicks(WORLD_CHANGE_GRACE_TICKS);
+            }
+        }
     }
 
     @Override

--- a/platform-fabric-1219/src/main/java/de/pianoman911/playerculling/platformfabric1219/PlayerCullingListener.java
+++ b/platform-fabric-1219/src/main/java/de/pianoman911/playerculling/platformfabric1219/PlayerCullingListener.java
@@ -9,6 +9,7 @@ import de.pianoman911.playerculling.platformfabric1219.common.IServerLevel;
 import de.pianoman911.playerculling.platformfabric1219.platform.FabricCommandSourceStack;
 import de.pianoman911.playerculling.platformfabric1219.platform.FabricWorld;
 import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
+import net.fabricmc.fabric.api.entity.event.v1.ServerEntityWorldChangeEvents;
 import net.fabricmc.fabric.api.entity.event.v1.ServerPlayerEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
@@ -26,10 +27,12 @@ public class PlayerCullingListener implements
         ServerPlayConnectionEvents.Join,
         ServerPlayConnectionEvents.Disconnect,
         ServerPlayerEvents.AfterRespawn,
+        ServerEntityWorldChangeEvents.AfterPlayerChange,
         ServerTickEvents.EndWorldTick,
         ServerLifecycleEvents.ServerStopped,
         CommandRegistrationCallback {
 
+    private static final long WORLD_CHANGE_GRACE_TICKS = 40L;
     private final PlayerCullingMod plugin;
 
     public PlayerCullingListener(PlayerCullingMod plugin) {
@@ -39,6 +42,7 @@ public class PlayerCullingListener implements
     public void register() {
         ServerPlayConnectionEvents.JOIN.register(this);
         ServerPlayConnectionEvents.DISCONNECT.register(this);
+        ServerEntityWorldChangeEvents.AFTER_PLAYER_CHANGE_WORLD.register(this);
         ServerTickEvents.END_WORLD_TICK.register(this);
         ServerLifecycleEvents.SERVER_STOPPED.register(this);
         CommandRegistrationCallback.EVENT.register(this);
@@ -62,6 +66,23 @@ public class PlayerCullingListener implements
             return; // cull player is null, ignore
         }
         player.setSpectating(false);
+    }
+
+    @Override
+    public void afterChangeWorld(ServerPlayer player, ServerLevel origin, ServerLevel destination) {
+        CullPlayer cullPlayer = this.plugin.getCullShip().getPlayer(player.getUUID());
+        if (cullPlayer != null) {
+            cullPlayer.resetHidden();
+            cullPlayer.setSpectating(false);
+            cullPlayer.forceVisibleForTicks(WORLD_CHANGE_GRACE_TICKS);
+        }
+        var destinationKey = ((IServerLevel) destination).getCullWorldOrCreate().getKey();
+        for (CullPlayer other : this.plugin.getCullShip().getPlayers()) {
+            other.invalidateOther(player.getUUID());
+            if (other.getPlatformPlayer().getWorld().getKey().equals(destinationKey)) {
+                other.forceVisibleForTicks(WORLD_CHANGE_GRACE_TICKS);
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
## Summary
Fix false player culling after nether roof transitions, portal world changes, and command teleports.

## Root Cause
- Ray stepping could continue outside the intended source to target segment and classify roof-adjacent players as occluded.
- Zero-step ray results were treated as occluded instead of visible.
- World changes could retain stale hidden state and per-world cache state.
- Large same-world teleports had no temporary culling grace window.

## Changes
- Constrained faced ray stepping to the source to target voxel segment.
- Stopped stepping once the target voxel is reached.
- Treated `scanOccluded` results `<= 0` as visible.
- Invalidated chunk cache on world switch in `ChunkOcclusionDataProvider`.
- Added Fabric `AFTER_PLAYER_CHANGE_WORLD` handling for 1.21.4, 1.21.7, 1.21.9, and 1.21.11.
- Cleared hidden state for moved players on world change.
- Invalidated moved player hidden entries on peers.
- Added short world-change visibility grace.
- Added teleport jump detection in `CullPlayer`.
- Added short visibility grace for large same-world position jumps.
- Added configurable close-range always-visible distance and README documentation.
