### PR TITLE
Fix occlusion cache errors and player visibility desyncs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,6 +43,10 @@ subprojects {
         options.encoding = Charsets.UTF_8.name()
     }
 
+    tasks.withType<Test> {
+        useJUnitPlatform()
+    }
+
     tasks.withType<Jar> {
         archiveBaseName = "${rootProject.name.lowercase()}-${project.name}"
 

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -1,4 +1,8 @@
 dependencies {
     api(projects.platformCommon)
     compileOnly(libs.google.gson)
+    testImplementation(libs.junit.jupiter)
+    testRuntimeOnly(libs.adventure.api)
+    testRuntimeOnly(libs.junit.platform.launcher)
+    testRuntimeOnly(libs.slf4j)
 }

--- a/core/src/main/java/de/pianoman911/playerculling/core/culling/CullPlayer.java
+++ b/core/src/main/java/de/pianoman911/playerculling/core/culling/CullPlayer.java
@@ -47,6 +47,7 @@ public final class CullPlayer {
 
     private boolean cullingEnabled = true;
     private boolean spectating = false;
+    private PlatformWorld world;
     private long lastDarkness = -1;
     private long lastRaySteps = 0L;
 
@@ -54,8 +55,9 @@ public final class CullPlayer {
         this.ship = ship;
         this.player = player;
         this.cullingInstance = new OcclusionCullingInstance(this.provider);
-        this.provider.world(player.getWorld());
-        this.tracked = new FastStack<>(player.getWorld().getPlayerCount());
+        this.world = player.getWorld();
+        this.provider.world(this.world);
+        this.tracked = new FastStack<>(this.world.getPlayerCount());
     }
 
     /**
@@ -129,6 +131,11 @@ public final class CullPlayer {
 
     private void cull0() {
         PlatformWorld world = this.player.getWorld();
+        if (!world.equals(this.world)) {
+            this.world = world;
+            this.provider.world(world);
+            this.hidden.clear();
+        }
         if (!this.cullingEnabled
                 || this.player.shouldPreventCulling()
                 || this.player.isSpectator()
@@ -142,9 +149,9 @@ public final class CullPlayer {
 
         List<PlatformPlayer> playersInWorld = world.getPlayers();
         if (playersInWorld.size() <= 1) {
+            this.hidden.clear();
             return; // No need to cull if no other players are in the world
         }
-        this.provider.world(world);
         Vec3d eye = this.player.getEyePosition();
 
         boolean blindness;
@@ -186,7 +193,8 @@ public final class CullPlayer {
             boolean nameTag = distSq <= nametagVisibilityDistSq && this.player.canSeeNameTag(worldPlayer);
 
             if (
-                    worldPlayer.isGlowing() || // Glowing player
+                    worldPlayer.shouldPreventCulling() || // Dead or otherwise lifecycle-sensitive player
+                            worldPlayer.isGlowing() || // Glowing player
                             !worldPlayer.isSneaking() && nameTag // Name tag visible and not sneaking
             ) { // Always visible
                 this.unhide(worldPlayer, distSq <= trackingDistSq);
@@ -328,7 +336,9 @@ public final class CullPlayer {
     }
 
     public void resetHidden() {
-        this.hidden.clear();
+        synchronized (this) {
+            this.hidden.clear();
+        }
     }
 
     public DataProvider getProvider() {

--- a/core/src/main/java/de/pianoman911/playerculling/core/culling/CullShip.java
+++ b/core/src/main/java/de/pianoman911/playerculling/core/culling/CullShip.java
@@ -144,6 +144,33 @@ public class CullShip {
         }
     }
 
+    /**
+     * Resets culling state which may refer to the old player entity after a respawn.
+     */
+    public void onPlayerRespawn(UUID uniqueId) {
+        CullPlayer respawnedPlayer;
+        Set<CullPlayer> currentPlayers;
+        synchronized (this.players) {
+            respawnedPlayer = this.players.get(uniqueId);
+            currentPlayers = Set.copyOf(this.players.values());
+        }
+        if (respawnedPlayer == null) {
+            return;
+        }
+
+        respawnedPlayer.setSpectating(false);
+        respawnedPlayer.resetHidden();
+
+        // A respawn replaces or resets the tracked Minecraft entity. Hidden entries for the old
+        // entity must not suppress pairing packets for the new one. Queue the removals so they
+        // cannot race with an in-progress asynchronous culling pass.
+        for (CullPlayer currentPlayer : currentPlayers) {
+            if (currentPlayer != respawnedPlayer) {
+                currentPlayer.invalidateOther(uniqueId);
+            }
+        }
+    }
+
     public long getLongestCullTime() {
         synchronized (this.containers) {
             long longest = 0;

--- a/core/src/main/java/de/pianoman911/playerculling/core/provider/ChunkOcclusionDataProvider.java
+++ b/core/src/main/java/de/pianoman911/playerculling/core/provider/ChunkOcclusionDataProvider.java
@@ -28,6 +28,7 @@ public final class ChunkOcclusionDataProvider implements DataProvider {
         if (!world.equals(this.world)) {
             this.world = world;
             this.cache = world.getOcclusionWorldCache();
+            this.chunk = null;
         }
     }
 

--- a/core/src/test/java/de/pianoman911/playerculling/core/provider/ChunkOcclusionDataProviderTest.java
+++ b/core/src/test/java/de/pianoman911/playerculling/core/provider/ChunkOcclusionDataProviderTest.java
@@ -1,0 +1,121 @@
+package de.pianoman911.playerculling.core.provider;
+
+import de.pianoman911.playerculling.platformcommon.platform.IPlatform;
+import de.pianoman911.playerculling.platformcommon.platform.entity.PlatformPlayer;
+import de.pianoman911.playerculling.platformcommon.platform.world.PlatformChunkAccess;
+import de.pianoman911.playerculling.platformcommon.platform.world.PlatformWorld;
+import de.pianoman911.playerculling.platformcommon.vector.Vec3d;
+import de.pianoman911.playerculling.platformcommon.vector.Vec3i;
+import net.kyori.adventure.key.Key;
+import org.junit.jupiter.api.Test;
+
+import java.awt.Color;
+import java.lang.reflect.Proxy;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ChunkOcclusionDataProviderTest {
+
+    @Test
+    @SuppressWarnings("DataFlowIssue")
+    void switchingWorldsInvalidatesChunkWithMatchingCoordinates() {
+        TestWorld opaqueWorld = new TestWorld(true);
+        TestWorld emptyWorld = new TestWorld(false);
+        ChunkOcclusionDataProvider provider = new ChunkOcclusionDataProvider(null);
+
+        provider.world(opaqueWorld);
+        assertTrue(provider.isOpaqueFullCube(0, 0, 0));
+
+        provider.world(emptyWorld);
+        assertFalse(provider.isOpaqueFullCube(0, 0, 0));
+    }
+
+    private static IPlatform testPlatform() {
+        return (IPlatform) Proxy.newProxyInstance(
+                IPlatform.class.getClassLoader(),
+                new Class<?>[]{IPlatform.class},
+                (proxy, method, args) -> {
+                    if (method.getName().equals("getCurrentTick")) {
+                        return 0L;
+                    }
+                    throw new UnsupportedOperationException(method.getName());
+                }
+        );
+    }
+
+    private static final class TestWorld extends PlatformWorld {
+
+        private final PlatformChunkAccess chunk;
+
+        private TestWorld(boolean opaque) {
+            super(testPlatform());
+            this.chunk = new PlatformChunkAccess() {
+                @Override
+                public int getBlockId(int x, int y, int z) {
+                    return 0;
+                }
+
+                @Override
+                public boolean isOpaque(int x, int y, int z, int voxelIndex) {
+                    return opaque;
+                }
+            };
+        }
+
+        @Override
+        public PlatformChunkAccess getChunkAccess(int x, int z) {
+            return x == 0 && z == 0 ? this.chunk : null;
+        }
+
+        @Override
+        public String getName() {
+            return "test";
+        }
+
+        @Override
+        public Key getKey() {
+            return Key.key("playerculling", "test");
+        }
+
+        @Override
+        public int getMinY() {
+            return 0;
+        }
+
+        @Override
+        public int getMaxY() {
+            return 1;
+        }
+
+        @Override
+        public int getTrackingDistance() {
+            return 0;
+        }
+
+        @Override
+        public int getTrackingDistance(PlatformPlayer player) {
+            return 0;
+        }
+
+        @Override
+        protected List<PlatformPlayer> getPlayers0() {
+            return List.of();
+        }
+
+        @Override
+        public Vec3d rayTraceBlocks(Vec3d start, Vec3d dir, double maxDistance) {
+            return null;
+        }
+
+        @Override
+        public void spawnColoredParticle(double x, double y, double z, Color color, float size) {
+        }
+
+        @Override
+        public String getBlockStateStringOfBlock(Vec3i blockPos) {
+            return "air";
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,8 @@ adventure-api = "4.20.0"
 slf4j = "2.0.17"
 jspecify = "1.0.0"
 checkerframework = "3.49.2"
+junit = "5.13.4"
+junit-platform = "1.13.4"
 
 configurate = "4.2.0"
 fastutil = "8.5.18"
@@ -74,6 +76,8 @@ adventure-api = { module = "net.kyori:adventure-api", version.ref = "adventure-a
 slf4j = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
 jspecify = { module = "org.jspecify:jspecify", version.ref = "jspecify" }
 checkerframework = { module = "org.checkerframework:checker-qual", version.ref = "checkerframework" }
+junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
+junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junit-platform" }
 
 configurate-core = { module = "org.spongepowered:configurate-core", version.ref = "configurate" }
 configurate-yaml = { module = "org.spongepowered:configurate-yaml", version.ref = "configurate" }

--- a/platform-common/build.gradle.kts
+++ b/platform-common/build.gradle.kts
@@ -4,4 +4,8 @@ dependencies {
     compileOnlyApi(libs.brigadier)
     compileOnly(libs.netty.all)
     api(projects.api)
+    testImplementation(libs.junit.jupiter)
+    testRuntimeOnly(libs.adventure.api)
+    testRuntimeOnly(libs.junit.platform.launcher)
+    testRuntimeOnly(libs.slf4j)
 }

--- a/platform-common/src/main/java/de/pianoman911/playerculling/platformcommon/cache/OcclusionChunkCache.java
+++ b/platform-common/src/main/java/de/pianoman911/playerculling/platformcommon/cache/OcclusionChunkCache.java
@@ -3,7 +3,6 @@ package de.pianoman911.playerculling.platformcommon.cache;
 
 import de.pianoman911.playerculling.platformcommon.platform.world.PlatformChunkAccess;
 import de.pianoman911.playerculling.platformcommon.util.OcclusionMappings;
-import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
@@ -20,14 +19,12 @@ public final class OcclusionChunkCache {
     public final int x;
     public final int z;
     private final OcclusionWorldCache world;
-    private volatile long @MonotonicNonNull [] occlusionData = null;
-    private volatile int minY;
-    private volatile int minYX2;
-    private volatile int maxY;
-    private volatile int height;
-    private volatile int heightX2;
-    private volatile boolean fullyComputed = false;
+    private final int worldMinY;
+    private final int worldMaxY;
+    private final int worldHeight;
+    private volatile CacheState state;
     private volatile boolean computing = false;
+    private long modificationVersion = 0L;
 
     private @Nullable WeakReference<PlatformChunkAccess> chunk;
 
@@ -41,11 +38,11 @@ public final class OcclusionChunkCache {
         this.x = x;
         this.z = z;
 
-        this.minY = world.getWorld().getMinY();
-        this.minYX2 = this.minY * 2;
-        this.maxY = world.getWorld().getMaxY();
-        this.height = this.maxY - this.minY;
-        this.heightX2 = this.height * 2;
+        this.worldMinY = world.getWorld().getMinY();
+        this.worldMaxY = world.getWorld().getMaxY();
+        this.worldHeight = this.worldMaxY - this.worldMinY;
+
+        this.state = this.uncomputedState();
 
         this.resolveChunkAccess(); // Trigger cache building
     }
@@ -85,23 +82,29 @@ public final class OcclusionChunkCache {
         return index(ix, iy, iz);
     }
 
-    public final boolean isOccluded(int index) {
-        return (this.occlusionData[index >>> 6] &  // index / 64 for long array index
+    private static boolean isOccluded(long[] data, int index) {
+        return (data[index >>> 6] &  // index / 64 for long array index
                 (1L << (index & 63))) != 0; // index % 64 for bit index inside long
     }
 
+    public final boolean isOccluded(int index) {
+        long[] data = this.state.data;
+        return data != null && isOccluded(data, index);
+    }
+
     public final boolean isOccluded(double x, double y, double z) {
-        y -= this.minY;
-        if (y < 0 || y >= this.height) {
+        CacheState state = this.state;
+        y -= state.minY;
+        if (y < 0 || y >= state.height) {
             return false;
         }
 
         int relX = Math.floorMod((int) (x * 2d), 16 * 2);
         int relZ = Math.floorMod((int) (z * 2d), 16 * 2);
 
-        if (this.fullyComputed) { // Fully computed -> use cache
+        if (state.data != null) { // Fully computed -> use cache
             int index = index(relX, (int) (y * 2d), relZ);
-            return this.isOccluded(index);
+            return isOccluded(state.data, index);
         }
 
         PlatformChunkAccess chunk = this.resolveChunkAccess();
@@ -110,7 +113,7 @@ public final class OcclusionChunkCache {
         }
 
         for (int i = 0; i < VOXEL_LENGTH; i++) {
-            if (chunk.isOpaque(relX >> 1, (int) y + this.minY, relZ >> 1, i)) {
+            if (chunk.isOpaque(relX >> 1, (int) y + state.minY, relZ >> 1, i)) {
                 return true;
             }
         }
@@ -118,19 +121,21 @@ public final class OcclusionChunkCache {
     }
 
     public final boolean isVoxelOccluded(int x, int y, int z) {
-        y -= this.minYX2;
-        if (y < 0 || y >= this.heightX2) {
+        CacheState state = this.state;
+        int minYX2 = state.minY * 2;
+        y -= minYX2;
+        if (y < 0 || y >= state.height * 2) {
             return false;
         }
-        if (this.fullyComputed) {
-            return this.isOccluded(index(x & 31, y, z & 31));
+        if (state.data != null) {
+            return isOccluded(state.data, index(x & 31, y, z & 31));
         }
-        return this.isOccluded(x / 2d, (y + this.minYX2) / 2d, z / 2d); // Only called if no cache is available
+        return this.isOccluded(x / 2d, (y + minYX2) / 2d, z / 2d); // Only called if no cache is available
     }
 
     void computeFully(@Nullable PlatformChunkAccess access) {
         synchronized (this) {
-            if (access == null || this.fullyComputed || this.computing) {
+            if (access == null || this.state.data != null || this.computing) {
                 return;
             }
             this.computing = true;
@@ -142,16 +147,23 @@ public final class OcclusionChunkCache {
         if (depth > MAX_CHUNK_COMPUTE_DEPTH) {
             LOGGER.warn("Failed to compute occlusion data for chunk at {}, {} after "
                     + MAX_CHUNK_COMPUTE_DEPTH + " retries", this.x, this.z);
-            this.computing = false;
+            synchronized (this) {
+                this.computing = false;
+            }
             return;
         }
         try {
-            int bottomY = this.height;
-            int topY = 0;
-            long[] data = new long[this.height * 4 * 8];
+            long startVersion;
+            synchronized (this) {
+                startVersion = this.modificationVersion;
+            }
 
-            for (int cy = 0; cy < this.height; cy++) {
-                int y = cy + this.minY;
+            int bottomY = this.worldMaxY;
+            int topY = this.worldMinY - 1;
+            long[] data = new long[this.worldHeight * 4 * 8];
+
+            for (int cy = 0; cy < this.worldHeight; cy++) {
+                int y = cy + this.worldMinY;
                 for (int cx = 0; cx < 16; cx++) {
                     for (int cz = 0; cz < 16; cz++) {
                         for (int i = 0; i < VOXEL_LENGTH; i++) {
@@ -170,23 +182,31 @@ public final class OcclusionChunkCache {
                 }
             }
 
-            int height = topY - bottomY + 1;
-            if (height != this.height) {
+            int height = Math.max(0, topY - bottomY + 1);
+            long[] computedData;
+            if (height == 0) {
+                computedData = new long[0];
+                bottomY = this.worldMinY;
+                topY = this.worldMinY - 1;
+            } else if (height != this.worldHeight) {
                 long[] minifiedData = new long[height * 4 * 8]; // resize data array to save memory
-                System.arraycopy(data, (bottomY - this.minY) * 4 * 8, minifiedData, 0, height * 4 * 8);
-                this.occlusionData = minifiedData;
+                System.arraycopy(data, (bottomY - this.worldMinY) * 4 * 8, minifiedData, 0, height * 4 * 8);
+                computedData = minifiedData;
             } else {
-                this.occlusionData = data;
+                computedData = data;
             }
 
-            this.minY = bottomY;
-            this.minYX2 = bottomY * 2;
-            this.maxY = topY;
-            this.height = height;
-            this.heightX2 = height * 2;
-
-            this.fullyComputed = true;
-            this.computing = false;
+            boolean retry;
+            synchronized (this) {
+                retry = startVersion != this.modificationVersion;
+                if (!retry) {
+                    this.state = new CacheState(computedData, bottomY, topY, height);
+                    this.computing = false;
+                }
+            }
+            if (retry) {
+                this.computeFully0(access, depth + 1);
+            }
         } catch (Throwable throwable) {
             LOGGER.error("Failed to compute occlusion data for chunk at {} {}", this.x, this.z, throwable);
             this.computeFully0(access, depth + 1); // retry
@@ -194,39 +214,47 @@ public final class OcclusionChunkCache {
     }
 
     public void recalculateBlock(int x, int y, int z) {
-        if (!this.fullyComputed) {
-            return;
-        }
-
-        x = x & 15;
-        z = z & 15;
-        y -= this.minY;
-        if (y < 0 || y >= this.height) { // out of range -> recalculate
-            int prevMin = this.minY;
-            int prevMax = this.maxY;
-            this.minY = Math.min(prevMin, y + prevMin);
-            this.maxY = Math.max(prevMax, y + prevMin);
-            int height = this.maxY - this.minY + 1;
-
-            long[] data = new long[height * 4 * 8];
-            System.arraycopy(this.occlusionData, (prevMin - this.minY) * 4 * 8, data, (prevMin - this.minY) * 4 * 8, (prevMax - prevMin + 1) * 4 * 8);
-            this.occlusionData = data;
-            this.height = height;
-            this.heightX2 = height * 2;
-            this.minYX2 = this.minY * 2;
-        }
         PlatformChunkAccess chunk = this.resolveChunkAccess();
         if (chunk == null) {
             return; // chunk is unloaded
         }
 
-        for (int i = 0; i < 8; i++) {
-            boolean opaque = chunk.isOpaque(x, y + this.minY, z, i);
-            double ix = x + (i & 1) * 0.5;
-            double iy = y + ((i >> 1) & 1) * 0.5;
-            double iz = z + ((i >> 2) & 1) * 0.5;
-            set(this.occlusionData, doubleDoubleIndex(ix, iy, iz), opaque);
+        boolean recompute = false;
+        synchronized (this) {
+            this.modificationVersion++;
+            CacheState state = this.state;
+            if (state.data == null) {
+                return;
+            }
+
+            x &= 15;
+            z &= 15;
+            y -= state.minY;
+            if (y < 0 || y >= state.height) {
+                // The minified cache cannot be resized safely while culling threads are reading it.
+                // Fall back to live chunk data until a new complete snapshot has been published.
+                this.state = this.uncomputedState();
+                recompute = true;
+            } else {
+                for (int i = 0; i < VOXEL_LENGTH; i++) {
+                    boolean opaque = chunk.isOpaque(x, y + state.minY, z, i);
+                    double ix = x + (i & 1) * 0.5;
+                    double iy = y + ((i >> 1) & 1) * 0.5;
+                    double iz = z + ((i >> 2) & 1) * 0.5;
+                    set(state.data, doubleDoubleIndex(ix, iy, iz), opaque);
+                }
+                // Publish the writes to the array through the volatile snapshot field.
+                this.state = new CacheState(state.data, state.minY, state.maxY, state.height);
+            }
         }
+
+        if (recompute) {
+            this.computeFully(chunk);
+        }
+    }
+
+    private CacheState uncomputedState() {
+        return new CacheState(null, this.worldMinY, this.worldMaxY - 1, this.worldHeight);
     }
 
     public OcclusionWorldCache getWorld() {
@@ -234,7 +262,7 @@ public final class OcclusionChunkCache {
     }
 
     final long[] getOcclusionData() {
-        return this.occlusionData;
+        return this.state.data;
     }
 
     public final int getX() {
@@ -246,19 +274,19 @@ public final class OcclusionChunkCache {
     }
 
     public final int getHeight() {
-        return this.height;
+        return this.state.height;
     }
 
     public final int getMinY() {
-        return this.minY;
+        return this.state.minY;
     }
 
     public final int getMaxY() {
-        return this.maxY;
+        return this.state.maxY;
     }
 
     public boolean isFullyComputed() {
-        return this.fullyComputed;
+        return this.state.data != null;
     }
 
     public final boolean[] isOpaqueFullBlock(int x, int y, int z) {
@@ -276,9 +304,13 @@ public final class OcclusionChunkCache {
 
     public final int byteSize() {
         int size = 21; // 21 bytes for the chunk cache object itself
-        if (this.occlusionData != null) {
-            size += this.occlusionData.length * Long.BYTES;
+        long[] data = this.state.data;
+        if (data != null) {
+            size += data.length * Long.BYTES;
         }
         return size;
+    }
+
+    private record CacheState(long @Nullable [] data, int minY, int maxY, int height) {
     }
 }

--- a/platform-common/src/test/java/de/pianoman911/playerculling/platformcommon/cache/OcclusionChunkCacheTest.java
+++ b/platform-common/src/test/java/de/pianoman911/playerculling/platformcommon/cache/OcclusionChunkCacheTest.java
@@ -1,0 +1,170 @@
+package de.pianoman911.playerculling.platformcommon.cache;
+
+import de.pianoman911.playerculling.platformcommon.platform.IPlatform;
+import de.pianoman911.playerculling.platformcommon.platform.entity.PlatformPlayer;
+import de.pianoman911.playerculling.platformcommon.platform.world.PlatformChunkAccess;
+import de.pianoman911.playerculling.platformcommon.platform.world.PlatformWorld;
+import de.pianoman911.playerculling.platformcommon.vector.Vec3d;
+import de.pianoman911.playerculling.platformcommon.vector.Vec3i;
+import net.kyori.adventure.key.Key;
+import org.junit.jupiter.api.Test;
+
+import java.awt.Color;
+import java.lang.reflect.Proxy;
+import java.time.Duration;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BooleanSupplier;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+class OcclusionChunkCacheTest {
+
+    @Test
+    void emptyChunkProducesEmptyComputedCache() throws InterruptedException {
+        TestWorld world = new TestWorld(-2, 3);
+        OcclusionChunkCache cache = world.getOcclusionWorldCache().chunk(0, 0);
+
+        await(cache::isFullyComputed);
+
+        assertEquals(0, cache.getHeight());
+        assertEquals(-2, cache.getMinY());
+        assertEquals(-3, cache.getMaxY());
+        assertEquals(0, cache.getOcclusionData().length);
+        assertFalse(cache.isVoxelOccluded(0, 0, 0));
+    }
+
+    @Test
+    void blockBelowMinifiedRangeRecomputesWithoutArrayCopyFailure() throws InterruptedException {
+        TestWorld world = new TestWorld(-2, 3);
+        world.chunk.setOpaque(0, 1, 0, 0, true);
+        OcclusionChunkCache cache = world.getOcclusionWorldCache().chunk(0, 0);
+        await(() -> cache.isFullyComputed() && cache.getMinY() == 1 && cache.getHeight() == 1);
+
+        world.chunk.setOpaque(0, 0, 0, 0, true);
+        assertDoesNotThrow(() -> cache.recalculateBlock(0, 0, 0));
+        await(() -> cache.isFullyComputed() && cache.getMinY() == 0 && cache.getHeight() == 2);
+
+        assertTrue(cache.isVoxelOccluded(0, 0, 0));
+        assertTrue(cache.isVoxelOccluded(0, 2, 0));
+    }
+
+    private static void await(BooleanSupplier condition) throws InterruptedException {
+        long deadline = System.nanoTime() + Duration.ofSeconds(5).toNanos();
+        while (!condition.getAsBoolean()) {
+            if (System.nanoTime() >= deadline) {
+                fail("Timed out waiting for occlusion cache computation");
+            }
+            Thread.sleep(10L);
+        }
+    }
+
+    private static IPlatform testPlatform() {
+        return (IPlatform) Proxy.newProxyInstance(
+                IPlatform.class.getClassLoader(),
+                new Class<?>[]{IPlatform.class},
+                (proxy, method, args) -> {
+                    if (method.getName().equals("getCurrentTick")) {
+                        return 0L;
+                    }
+                    throw new UnsupportedOperationException(method.getName());
+                }
+        );
+    }
+
+    private static final class TestWorld extends PlatformWorld {
+
+        private final TestChunk chunk = new TestChunk();
+        private final int minY;
+        private final int maxY;
+
+        private TestWorld(int minY, int maxY) {
+            super(testPlatform());
+            this.minY = minY;
+            this.maxY = maxY;
+        }
+
+        @Override
+        public PlatformChunkAccess getChunkAccess(int x, int z) {
+            return x == 0 && z == 0 ? this.chunk : null;
+        }
+
+        @Override
+        public String getName() {
+            return "test";
+        }
+
+        @Override
+        public Key getKey() {
+            return Key.key("playerculling", "test");
+        }
+
+        @Override
+        public int getMinY() {
+            return this.minY;
+        }
+
+        @Override
+        public int getMaxY() {
+            return this.maxY;
+        }
+
+        @Override
+        public int getTrackingDistance() {
+            return 0;
+        }
+
+        @Override
+        public int getTrackingDistance(PlatformPlayer player) {
+            return 0;
+        }
+
+        @Override
+        protected List<PlatformPlayer> getPlayers0() {
+            return List.of();
+        }
+
+        @Override
+        public Vec3d rayTraceBlocks(Vec3d start, Vec3d dir, double maxDistance) {
+            return null;
+        }
+
+        @Override
+        public void spawnColoredParticle(double x, double y, double z, Color color, float size) {
+        }
+
+        @Override
+        public String getBlockStateStringOfBlock(Vec3i blockPos) {
+            return "air";
+        }
+    }
+
+    private static final class TestChunk implements PlatformChunkAccess {
+
+        private final Set<String> opaque = ConcurrentHashMap.newKeySet();
+
+        private void setOpaque(int x, int y, int z, int voxelIndex, boolean value) {
+            String key = x + ":" + y + ":" + z + ":" + voxelIndex;
+            if (value) {
+                this.opaque.add(key);
+            } else {
+                this.opaque.remove(key);
+            }
+        }
+
+        @Override
+        public int getBlockId(int x, int y, int z) {
+            return 0;
+        }
+
+        @Override
+        public boolean isOpaque(int x, int y, int z, int voxelIndex) {
+            return this.opaque.contains(x + ":" + y + ":" + z + ":" + voxelIndex);
+        }
+    }
+}

--- a/platform-fabric-12111/src/main/java/de/pianoman911/playerculling/platformfabric12111/PlayerCullingListener.java
+++ b/platform-fabric-12111/src/main/java/de/pianoman911/playerculling/platformfabric12111/PlayerCullingListener.java
@@ -57,11 +57,7 @@ public class PlayerCullingListener implements
 
     @Override
     public void afterRespawn(ServerPlayer oldPlayer, ServerPlayer newPlayer, boolean alive) {
-        CullPlayer player = this.plugin.getCullShip().getPlayer(newPlayer.getUUID());
-        if (player == null) {
-            return; // cull player is null, ignore
-        }
-        player.setSpectating(false);
+        this.plugin.getCullShip().onPlayerRespawn(newPlayer.getUUID());
     }
 
     @Override

--- a/platform-fabric-12111/src/main/java/de/pianoman911/playerculling/platformfabric12111/platform/FabricEntity.java
+++ b/platform-fabric-12111/src/main/java/de/pianoman911/playerculling/platformfabric12111/platform/FabricEntity.java
@@ -30,9 +30,9 @@ public class FabricEntity<T extends Entity> implements PlatformEntity {
         this.platform = platform;
         this.entity = sender;
         this.position = new TickRefreshSupplier<>(platform, () ->
-                new Vec3d(sender.getX(), sender.getY(), sender.getZ()));
+                new Vec3d(this.entity.getX(), this.entity.getY(), this.entity.getZ()));
         this.aabb = new TickRefreshSupplier<>(platform, () -> {
-            net.minecraft.world.phys.AABB boundingBox = sender.getBoundingBox();
+            net.minecraft.world.phys.AABB boundingBox = this.entity.getBoundingBox();
             return new AABB(boundingBox.minX, boundingBox.minY, boundingBox.minZ, boundingBox.maxX, boundingBox.maxY, boundingBox.maxZ);
         });
     }

--- a/platform-fabric-12111/src/main/java/de/pianoman911/playerculling/platformfabric12111/platform/FabricWorld.java
+++ b/platform-fabric-12111/src/main/java/de/pianoman911/playerculling/platformfabric12111/platform/FabricWorld.java
@@ -88,7 +88,7 @@ public class FabricWorld extends PlatformWorld {
         for (FabricPlayer platformPlayer : this.platform.getPlayers()) {
             ServerPlayer fabricPlayer = platformPlayer.getDelegate();
             if (fabricPlayer.connection.isAcceptingMessages() && fabricPlayer.level() == this.world
-                    && !fabricPlayer.isSpectator() && !platformPlayer.shouldPreventCulling()) {
+                    && !fabricPlayer.isSpectator()) {
                 players.add(platformPlayer);
             }
         }

--- a/platform-fabric-1214/src/main/java/de/pianoman911/playerculling/platformfabric1214/PlayerCullingListener.java
+++ b/platform-fabric-1214/src/main/java/de/pianoman911/playerculling/platformfabric1214/PlayerCullingListener.java
@@ -57,11 +57,7 @@ public class PlayerCullingListener implements
 
     @Override
     public void afterRespawn(ServerPlayer oldPlayer, ServerPlayer newPlayer, boolean alive) {
-        CullPlayer player = this.plugin.getCullShip().getPlayer(newPlayer.getUUID());
-        if (player == null) {
-            return; // cull player is null, ignore
-        }
-        player.setSpectating(false);
+        this.plugin.getCullShip().onPlayerRespawn(newPlayer.getUUID());
     }
 
     @Override

--- a/platform-fabric-1214/src/main/java/de/pianoman911/playerculling/platformfabric1214/platform/FabricEntity.java
+++ b/platform-fabric-1214/src/main/java/de/pianoman911/playerculling/platformfabric1214/platform/FabricEntity.java
@@ -29,9 +29,9 @@ public class FabricEntity<T extends Entity> implements PlatformEntity {
         this.platform = platform;
         this.entity = sender;
         this.position = new TickRefreshSupplier<>(platform, () ->
-                new Vec3d(sender.getX(), sender.getY(), sender.getZ()));
+                new Vec3d(this.entity.getX(), this.entity.getY(), this.entity.getZ()));
         this.aabb = new TickRefreshSupplier<>(platform, () -> {
-            net.minecraft.world.phys.AABB boundingBox = sender.getBoundingBox();
+            net.minecraft.world.phys.AABB boundingBox = this.entity.getBoundingBox();
             return new AABB(boundingBox.minX, boundingBox.minY, boundingBox.minZ, boundingBox.maxX, boundingBox.maxY, boundingBox.maxZ);
         });
     }

--- a/platform-fabric-1214/src/main/java/de/pianoman911/playerculling/platformfabric1214/platform/FabricWorld.java
+++ b/platform-fabric-1214/src/main/java/de/pianoman911/playerculling/platformfabric1214/platform/FabricWorld.java
@@ -88,7 +88,7 @@ public class FabricWorld extends PlatformWorld {
         for (FabricPlayer platformPlayer : this.platform.getPlayers()) {
             ServerPlayer fabricPlayer = platformPlayer.getDelegate();
             if (fabricPlayer.connection.isAcceptingMessages() && fabricPlayer.level() == this.world
-                    && !fabricPlayer.isSpectator() && !platformPlayer.shouldPreventCulling()) {
+                    && !fabricPlayer.isSpectator()) {
                 players.add(platformPlayer);
             }
         }

--- a/platform-fabric-1217/src/main/java/de/pianoman911/playerculling/platformfabric1217/PlayerCullingListener.java
+++ b/platform-fabric-1217/src/main/java/de/pianoman911/playerculling/platformfabric1217/PlayerCullingListener.java
@@ -57,11 +57,7 @@ public class PlayerCullingListener implements
 
     @Override
     public void afterRespawn(ServerPlayer oldPlayer, ServerPlayer newPlayer, boolean alive) {
-        CullPlayer player = this.plugin.getCullShip().getPlayer(newPlayer.getUUID());
-        if (player == null) {
-            return; // cull player is null, ignore
-        }
-        player.setSpectating(false);
+        this.plugin.getCullShip().onPlayerRespawn(newPlayer.getUUID());
     }
 
     @Override

--- a/platform-fabric-1217/src/main/java/de/pianoman911/playerculling/platformfabric1217/platform/FabricEntity.java
+++ b/platform-fabric-1217/src/main/java/de/pianoman911/playerculling/platformfabric1217/platform/FabricEntity.java
@@ -29,9 +29,9 @@ public class FabricEntity<T extends Entity> implements PlatformEntity {
         this.platform = platform;
         this.entity = sender;
         this.position = new TickRefreshSupplier<>(platform, () ->
-                new Vec3d(sender.getX(), sender.getY(), sender.getZ()));
+                new Vec3d(this.entity.getX(), this.entity.getY(), this.entity.getZ()));
         this.aabb = new TickRefreshSupplier<>(platform, () -> {
-            net.minecraft.world.phys.AABB boundingBox = sender.getBoundingBox();
+            net.minecraft.world.phys.AABB boundingBox = this.entity.getBoundingBox();
             return new AABB(boundingBox.minX, boundingBox.minY, boundingBox.minZ, boundingBox.maxX, boundingBox.maxY, boundingBox.maxZ);
         });
     }

--- a/platform-fabric-1217/src/main/java/de/pianoman911/playerculling/platformfabric1217/platform/FabricWorld.java
+++ b/platform-fabric-1217/src/main/java/de/pianoman911/playerculling/platformfabric1217/platform/FabricWorld.java
@@ -88,7 +88,7 @@ public class FabricWorld extends PlatformWorld {
         for (FabricPlayer platformPlayer : this.platform.getPlayers()) {
             ServerPlayer fabricPlayer = platformPlayer.getDelegate();
             if (fabricPlayer.connection.isAcceptingMessages() && fabricPlayer.level() == this.world
-                    && !fabricPlayer.isSpectator() && !platformPlayer.shouldPreventCulling()) {
+                    && !fabricPlayer.isSpectator()) {
                 players.add(platformPlayer);
             }
         }

--- a/platform-fabric-1219/src/main/java/de/pianoman911/playerculling/platformfabric1219/PlayerCullingListener.java
+++ b/platform-fabric-1219/src/main/java/de/pianoman911/playerculling/platformfabric1219/PlayerCullingListener.java
@@ -57,11 +57,7 @@ public class PlayerCullingListener implements
 
     @Override
     public void afterRespawn(ServerPlayer oldPlayer, ServerPlayer newPlayer, boolean alive) {
-        CullPlayer player = this.plugin.getCullShip().getPlayer(newPlayer.getUUID());
-        if (player == null) {
-            return; // cull player is null, ignore
-        }
-        player.setSpectating(false);
+        this.plugin.getCullShip().onPlayerRespawn(newPlayer.getUUID());
     }
 
     @Override

--- a/platform-fabric-1219/src/main/java/de/pianoman911/playerculling/platformfabric1219/platform/FabricEntity.java
+++ b/platform-fabric-1219/src/main/java/de/pianoman911/playerculling/platformfabric1219/platform/FabricEntity.java
@@ -29,9 +29,9 @@ public class FabricEntity<T extends Entity> implements PlatformEntity {
         this.platform = platform;
         this.entity = sender;
         this.position = new TickRefreshSupplier<>(platform, () ->
-                new Vec3d(sender.getX(), sender.getY(), sender.getZ()));
+                new Vec3d(this.entity.getX(), this.entity.getY(), this.entity.getZ()));
         this.aabb = new TickRefreshSupplier<>(platform, () -> {
-            net.minecraft.world.phys.AABB boundingBox = sender.getBoundingBox();
+            net.minecraft.world.phys.AABB boundingBox = this.entity.getBoundingBox();
             return new AABB(boundingBox.minX, boundingBox.minY, boundingBox.minZ, boundingBox.maxX, boundingBox.maxY, boundingBox.maxZ);
         });
     }

--- a/platform-fabric-1219/src/main/java/de/pianoman911/playerculling/platformfabric1219/platform/FabricWorld.java
+++ b/platform-fabric-1219/src/main/java/de/pianoman911/playerculling/platformfabric1219/platform/FabricWorld.java
@@ -88,7 +88,7 @@ public class FabricWorld extends PlatformWorld {
         for (FabricPlayer platformPlayer : this.platform.getPlayers()) {
             ServerPlayer fabricPlayer = platformPlayer.getDelegate();
             if (fabricPlayer.connection.isAcceptingMessages() && fabricPlayer.level() == this.world
-                    && !fabricPlayer.isSpectator() && !platformPlayer.shouldPreventCulling()) {
+                    && !fabricPlayer.isSpectator()) {
                 players.add(platformPlayer);
             }
         }

--- a/platform-fabric-2612/src/main/java/de/pianoman911/playerculling/platformfabric2612/PlayerCullingListener.java
+++ b/platform-fabric-2612/src/main/java/de/pianoman911/playerculling/platformfabric2612/PlayerCullingListener.java
@@ -57,11 +57,7 @@ public class PlayerCullingListener implements
 
     @Override
     public void afterRespawn(ServerPlayer oldPlayer, ServerPlayer newPlayer, boolean alive) {
-        CullPlayer player = this.plugin.getCullShip().getPlayer(newPlayer.getUUID());
-        if (player == null) {
-            return; // cull player is null, ignore
-        }
-        player.setSpectating(false);
+        this.plugin.getCullShip().onPlayerRespawn(newPlayer.getUUID());
     }
 
     @Override

--- a/platform-fabric-2612/src/main/java/de/pianoman911/playerculling/platformfabric2612/platform/FabricEntity.java
+++ b/platform-fabric-2612/src/main/java/de/pianoman911/playerculling/platformfabric2612/platform/FabricEntity.java
@@ -30,9 +30,9 @@ public class FabricEntity<T extends Entity> implements PlatformEntity {
         this.platform = platform;
         this.entity = sender;
         this.position = new TickRefreshSupplier<>(platform, () ->
-                new Vec3d(sender.getX(), sender.getY(), sender.getZ()));
+                new Vec3d(this.entity.getX(), this.entity.getY(), this.entity.getZ()));
         this.aabb = new TickRefreshSupplier<>(platform, () -> {
-            net.minecraft.world.phys.AABB boundingBox = sender.getBoundingBox();
+            net.minecraft.world.phys.AABB boundingBox = this.entity.getBoundingBox();
             return new AABB(boundingBox.minX, boundingBox.minY, boundingBox.minZ, boundingBox.maxX, boundingBox.maxY, boundingBox.maxZ);
         });
     }

--- a/platform-fabric-2612/src/main/java/de/pianoman911/playerculling/platformfabric2612/platform/FabricWorld.java
+++ b/platform-fabric-2612/src/main/java/de/pianoman911/playerculling/platformfabric2612/platform/FabricWorld.java
@@ -85,7 +85,7 @@ public class FabricWorld extends PlatformWorld {
         for (FabricPlayer platformPlayer : this.platform.getPlayers()) {
             ServerPlayer fabricPlayer = platformPlayer.getDelegate();
             if (fabricPlayer.connection.isAcceptingMessages() && fabricPlayer.level() == this.world
-                    && !fabricPlayer.isSpectator() && !platformPlayer.shouldPreventCulling()) {
+                    && !fabricPlayer.isSpectator()) {
                 players.add(platformPlayer);
             }
         }

--- a/platform-paper/src/main/java/de/pianoman911/playerculling/platformpaper/PlayerCullingListener.java
+++ b/platform-paper/src/main/java/de/pianoman911/playerculling/platformpaper/PlayerCullingListener.java
@@ -46,11 +46,7 @@ public class PlayerCullingListener implements Listener {
 
     @EventHandler
     public void onRespawn(PlayerPostRespawnEvent event) {
-        CullPlayer player = this.plugin.getCullShip().getPlayer(event.getPlayer().getUniqueId());
-        if (player == null) {
-            return; // cull player is null, ignore
-        }
-        player.setSpectating(false);
+        this.plugin.getCullShip().onPlayerRespawn(event.getPlayer().getUniqueId());
     }
 
     @EventHandler

--- a/platform-paper/src/main/java/de/pianoman911/playerculling/platformpaper/platform/PaperWorld.java
+++ b/platform-paper/src/main/java/de/pianoman911/playerculling/platformpaper/platform/PaperWorld.java
@@ -73,7 +73,7 @@ public class PaperWorld extends PlatformWorld {
         for (PaperPlayer platformPlayer : this.platform.getPlayers()) {
             Player paperPlayer = platformPlayer.getDelegate();
             if (paperPlayer.isConnected() && paperPlayer.getWorld() == this.world
-                    && !platformPlayer.isSpectator() && !platformPlayer.shouldPreventCulling()) {
+                    && !platformPlayer.isSpectator()) {
                 players.add(platformPlayer);
             }
         }


### PR DESCRIPTION
## Summary

- reset stale hidden-player state on respawn and dimension changes
- keep dead players visible and refresh Fabric wrappers against the replacement player entity
- invalidate the cached chunk when the culling data provider switches worlds
- publish occlusion cache data and vertical bounds as one consistent snapshot
- handle empty chunks without negative array sizes and recompute safely when blocks change outside a minified cache
- add regression coverage for empty chunks, downward cache growth, and same-coordinate world switches

## Issues

- Fixes #13
- Fixes #14
- Fixes #15
- Fixes #16
- Related to #7: both linked mclo.gs logs now return 404. The crash-prevention guard described by that report is already present on master via `100f1ce`; this PR additionally hardens the cache concurrency and retry paths. Without the original traces, #7 remains for maintainer follow-up.

## Verification

- `gradlew :platform-common:test :core:test :platform-paper:compileJava --configure-on-demand --offline`
- Full repository GitHub Actions build, including all Paper, Folia, and Fabric targets
- Build artifacts uploaded successfully

CI: https://github.com/Minecraft0122/PlayerCulling/actions/runs/29930646207